### PR TITLE
Package の Swift 6 対応（ワーニング対応も含む）

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,9 +12,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "FABoLLValueShowableSlider",
-            targets: [
-                "FABoLLValueShowableSlider",
-            ]),
+            targets: ["FABoLLValueShowableSlider"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -33,7 +31,7 @@ let package = Package(
             name: "FABoLLValueShowableSliderTests",
             dependencies: ["FABoLLValueShowableSlider"]),
     ],
-    swiftLanguageVersions: [
-        .v5,
+    swiftLanguageModes: [
+        .v6,
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # FABoLLValueShowableSlider
 
-[![FABoLL](https://custom-icon-badges.herokuapp.com/badge/license-FABoLL-8BB80A.svg?logo=law&logoColor=white)]()　[![iOS 16.0](https://custom-icon-badges.herokuapp.com/badge/iOS-16.0-007bff.svg?logo=apple&logoColor=white)]()　[![Xcode 15.3](https://custom-icon-badges.herokuapp.com/badge/Xcode-15.3-007bff.svg?logo=Xcode&logoColor=white)]()　[![Swift 5.9](https://custom-icon-badges.herokuapp.com/badge/Swift-5.9-df5c43.svg?logo=Swift&logoColor=white)]()
+[![FABoLL](https://custom-icon-badges.herokuapp.com/badge/license-FABoLL-8BB80A.svg?logo=law&logoColor=white)]()　
+[![iOS 16.0](https://custom-icon-badges.herokuapp.com/badge/iOS-16.0-007bff.svg?logo=apple&logoColor=white)]()　
+[![Xcode 16.2](https://custom-icon-badges.herokuapp.com/badge/Xcode-16.2-007bff.svg?logo=Xcode&logoColor=white)]()　
+[![Swift 6.0](https://custom-icon-badges.herokuapp.com/badge/Swift-6.0-df5c43.svg?logo=Swift&logoColor=white)]()
 
 You can show a slider value on the UISlider thumbnail.  
 And you can change a slider value by tap it.
@@ -33,8 +36,11 @@ If you want to change size:
 ```swift
 let settings = FABoLLValueShowableSliderSettings(
     label: label,
-    padding: UIEdgeInsets.init(top: -5, left: -4, bottom: -3, right: -4)
+    padding: UIEdgeInsets(top: -5, left: -4, bottom: -3, right: -4)
 )
+// OR
+var settings = FABoLLValueShowableSliderSettings(label: label)
+settings.update(\.padding, UIEdgeInsets(top: -5, left: -4, bottom: -3, right: -4))
 ```
 
 Full parameters:
@@ -43,7 +49,7 @@ Full parameters:
 let settings = FABoLLValueShowableSliderSettings(
     label: label,
     isRoundedCorner: true,
-    padding: UIEdgeInsets.init(top: 0, left: 0, bottom: 2, right: 0),
+    padding: UIEdgeInsets(top: 0, left: 0, bottom: 2, right: 0),
     valueToString: { value in
         return String(format: "%d", Int(value * 100)) + "%"
     },

--- a/Sources/FABoLLValueShowableSlider/FABoLLValueShowableSlider.swift
+++ b/Sources/FABoLLValueShowableSlider/FABoLLValueShowableSlider.swift
@@ -1,51 +1,26 @@
 //
 //  FABoLLValueShowableSlider
 //
-//  Created by Masakiyo Tachikawa on 2020/03/05.
-//  Copyright © 2020 FABoLL. All rights reserved.
-//
-//  Copyright 2020 Masakiyo Tachikawa
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in
-//  all copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-//  THE SOFTWARE.
-//
 //  © 2023 Masakiyo Tachikawa
 //
 
 import UIKit
 
-// MARK: - FABoLLValueShowableSlider
-
 public class FABoLLValueShowableSlider: UISlider {
 
     // MARK: - Properties
-
-    public override var value: Float {
-        didSet {
-            settings.label.text = settings.valueToString(value)
-        }
-    }
 
     let tapJudging: FABoLLValueShowableSliderTapJudging = .init()
 
     private(set) var settings: FABoLLValueShowableSliderSettings = .init(label: UILabel())
 
     private var thumbnail: UIImageView?
+
+    public override var value: Float {
+        didSet {
+            settings.label.text = settings.valueToString(value)
+        }
+    }
 
     // MARK: - Life cycle
 
@@ -63,12 +38,8 @@ public class FABoLLValueShowableSlider: UISlider {
 
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
-        if !settings.canChangeTapped {
-            return
-        }
-        guard let point: CGPoint = touches.first?.location(in: self) else {
-            return
-        }
+        if !settings.canChangeTapped { return }
+        guard let point: CGPoint = touches.first?.location(in: self) else { return }
         tapJudging.began(self, point)
     }
 
@@ -79,12 +50,8 @@ public class FABoLLValueShowableSlider: UISlider {
 
     public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
-        if !settings.canChangeTapped {
-            return
-        }
-        guard let point: CGPoint = touches.first?.location(in: self) else {
-            return
-        }
+        if !settings.canChangeTapped { return }
+        guard let point: CGPoint = touches.first?.location(in: self) else { return }
         tapJudging.ended(point)
     }
 

--- a/Sources/FABoLLValueShowableSlider/FABoLLValueShowableSliderSettings.swift
+++ b/Sources/FABoLLValueShowableSlider/FABoLLValueShowableSliderSettings.swift
@@ -6,35 +6,33 @@
 
 import UIKit
 
-// MARK: - FABoLLValueShowableSliderSettings
-
-public struct FABoLLValueShowableSliderSettings {
+public struct FABoLLValueShowableSliderSettings: Sendable {
 
     // MARK: - Properties
 
-    let label: UILabel
+    public private(set) var label: UILabel
     /// If you do not want a label  to round, please set `false`.
     ///
     /// Default is `true`.
-    let isRoundedCorner: Bool
+    public private(set) var isRoundedCorner: Bool
     /// Margin between UILabel and thumbnail UIImageView.
     ///
     /// Default UIEdgeInsets:
     /// ```
     /// UIEdgeInsets(top: 0, left: 1, bottom: 2, right: 1)
     /// ```
-    let padding: UIEdgeInsets
+    public private(set) var padding: UIEdgeInsets
     /// Closure to make string by UISlider.value.
     ///
     /// Default closure:
     /// ```
     /// { value in "\(Int(value * 100))" }
     /// ```
-    let valueToString: ((Float) -> String)
+    public private(set) var valueToString: (@Sendable (Float) -> String)
     /// If you want to change a slider value by tapping, please set `true`.
     ///
     /// Default is `false`.
-    let canChangeTapped: Bool
+    public private(set) var canChangeTapped: Bool
 
     // MARK: - Life cycle
 
@@ -65,7 +63,7 @@ public struct FABoLLValueShowableSliderSettings {
         label: UILabel,
         isRoundedCorner: Bool? = true,
         padding: UIEdgeInsets? = UIEdgeInsets(top: 0, left: 1, bottom: 2, right: 1),
-        valueToString: ((Float) -> String)? = { value in "\(Int(value * 100))" },
+        valueToString: (@Sendable (Float) -> String)? = { value in "\(Int(value * 100))" },
         canChangeTapped: Bool? = false
     ) {
         self.label = label
@@ -73,5 +71,13 @@ public struct FABoLLValueShowableSliderSettings {
         self.padding = padding!
         self.valueToString = valueToString!
         self.canChangeTapped = canChangeTapped!
+    }
+
+    public mutating func update<T>(_ key: KeyPath<Self, T>, _ value: T) {
+        guard let writableKey = key as? WritableKeyPath<Self, T> else {
+            assertionFailure("KeyPath変換で問題発生")
+            return
+        }
+        self[keyPath: writableKey] = value
     }
 }

--- a/Sources/FABoLLValueShowableSlider/FABoLLValueShowableSliderTapJudging.swift
+++ b/Sources/FABoLLValueShowableSlider/FABoLLValueShowableSliderTapJudging.swift
@@ -1,31 +1,10 @@
 //
-//  FABoLLValueShowableSliderTapJudging.swift
+//  FABoLLValueShowableSliderTapJudging
 //
-//  Created by Masakiyo Tachikawa on 2020/03/05.
-//  Copyright © 2020 FABoLL. All rights reserved.
-//
-//  Copyright 2020 Masakiyo Tachikawa
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in
-//  all copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-//  THE SOFTWARE.
+//  © 2023 Masakiyo Tachikawa
 //
 
-import UIKit
+import Foundation
 
 // MARK: - FABoLLValueShowableSliderTapJudging
 
@@ -50,22 +29,20 @@ final class FABoLLValueShowableSliderTapJudging {
 
     func began(_ slider: FABoLLValueShowableSlider, _ point: CGPoint) {
         let now: TimeInterval = Date.init().timeIntervalSince1970
-        if now - tapEnded > 0.2, tapAction == nil {
-            beganPoint = point
-            tapAction = { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                let value = Float(point.x / slider.bounds.width) * slider.maximumValue
-                slider.value = value
-                slider.sendActions(for: .valueChanged)
-                slider.sendActions(for: .touchUpInside)
-                self.tapAction = nil
-            }
-            // If the tap time exceeds  0.4 seconds, it is judge as a long tap
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
-                self?.tapAction = nil
-            }
+        guard now - tapEnded > 0.2, tapAction == nil else { return }
+        beganPoint = point
+        tapAction = { [weak self] in
+            guard let self = self else { return }
+            let value = Float(point.x / slider.bounds.width) * slider.maximumValue
+            slider.value = value
+            slider.sendActions(for: .valueChanged)
+            slider.sendActions(for: .touchUpInside)
+            self.tapAction = nil
+        }
+        // If the tap time exceeds  0.4 seconds, it is judge as a long tap
+        Task {
+            try await Task.sleep(for: .seconds(0.4))
+            tapAction = nil
         }
     }
 
@@ -81,8 +58,9 @@ final class FABoLLValueShowableSliderTapJudging {
         }
         tapEnded = Date().timeIntervalSince1970
         // Delay the action to determine if the tap is continuous
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) { [weak self] in
-            self?.tapAction?()
+        Task {
+            try await Task.sleep(for: .seconds(0.2))
+            tapAction?()
         }
     }
 }

--- a/Tests/FABoLLValueShowableSliderTests/FABoLLValueShowableSliderTest.swift
+++ b/Tests/FABoLLValueShowableSliderTests/FABoLLValueShowableSliderTest.swift
@@ -1,34 +1,21 @@
+//
+//  FABoLLValueShowableSliderTest
+//
+//  © 2023 Masakiyo Tachikawa
+//
+
+import Testing
 import XCTest
 @testable import FABoLLValueShowableSlider
 
-final class FABoLLValueShowableSliderTests: XCTestCase {
-
-    // MARK: - Static Properties
-
-    static var allTests = [
-        ("testSetup", testSetup),
-    ]
-
-    // MARK: - Properties
+@MainActor
+struct FABoLLValueShowableSliderTest {
 
     private let base = UIView(frame: UIScreen.main.bounds)
-
     private let valueShowableSlider = FABoLLValueShowableSlider()
-
     private let label = UILabel()
 
-    private func wait(_ time: TimeInterval) {
-        let expectation: XCTestExpectation = XCTestExpectation.init(description: "delay")
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + time) {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: time + 1)
-    }
-
-    // MARK: - tests
-
-    override func setUp() {
-        super.setUp()
+    @Test func test() async throws {
         base.addSubview(valueShowableSlider)
         valueShowableSlider.frame = CGRect(
             origin: .zero,
@@ -41,10 +28,8 @@ final class FABoLLValueShowableSliderTests: XCTestCase {
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.5
         label.textAlignment = .center
-    }
 
-    func testSetup() {
-        let settings = FABoLLValueShowableSliderSettings(
+        var settings = FABoLLValueShowableSliderSettings(
             label: label,
             isRoundedCorner: true,
             valueToString: { value in
@@ -58,17 +43,8 @@ final class FABoLLValueShowableSliderTests: XCTestCase {
         XCTAssertEqual(label.text, "0%")
         valueShowableSlider.value = 0.5
         XCTAssertEqual(label.text, "50%")
-    }
 
-    @MainActor func testSetupCanChangeTapped() {
-        let settings = FABoLLValueShowableSliderSettings(
-            label: label,
-            isRoundedCorner: true,
-            valueToString: { value in
-                return String(format: "%d", Int(value * 100)) + "%"
-            },
-            canChangeTapped: true
-        )
+        settings.update(\.canChangeTapped, true)
         valueShowableSlider.setLabel(settings: settings)
         valueShowableSlider.value = 1
         XCTAssertEqual(label.text, "100%")
@@ -83,11 +59,9 @@ final class FABoLLValueShowableSliderTests: XCTestCase {
             y: valueShowableSlider.bounds.height * 0.5
         )
         valueShowableSlider.tapJudging.began(valueShowableSlider, point)
-        wait(0.5)
         valueShowableSlider.tapJudging.ended(point)
         // The value does not change because it is judged as a long tap
         XCTAssertEqual(label.text, "50%")
-        wait(0.5)
 
         valueShowableSlider.tapJudging.began(valueShowableSlider, point)
         valueShowableSlider.tapJudging.ended(point)
@@ -95,15 +69,12 @@ final class FABoLLValueShowableSliderTests: XCTestCase {
         valueShowableSlider.tapJudging.ended(point)
         // The value does not change because it is judged as a long tap
         XCTAssertEqual(label.text, "50%")
-        wait(0.5)
 
         valueShowableSlider.tapJudging.began(valueShowableSlider, point)
         valueShowableSlider.tapJudging.ended(point)
-        wait(0.2)
         // The value changes
         XCTAssertEqual(valueShowableSlider.value, 0.25)
         XCTAssertEqual(label.text, "25%")
-        wait(0.5)
 
         point = CGPoint(
             x: valueShowableSlider.bounds.width * 0.75,
@@ -111,7 +82,6 @@ final class FABoLLValueShowableSliderTests: XCTestCase {
         )
         valueShowableSlider.tapJudging.began(valueShowableSlider, point)
         valueShowableSlider.tapJudging.ended(point)
-        wait(0.2)
         // The value changes
         XCTAssertEqual(valueShowableSlider.value, 0.75)
         XCTAssertEqual(label.text, "75%")
@@ -126,7 +96,6 @@ final class FABoLLValueShowableSliderTests: XCTestCase {
         )
         valueShowableSlider.tapJudging.began(valueShowableSlider, point)
         valueShowableSlider.tapJudging.ended(point2)
-        wait(0.2)
         // The value does not change because it is judged as a pan gesture
         XCTAssertEqual(valueShowableSlider.value, 0.75)
         XCTAssertEqual(label.text, "75%")

--- a/Tests/FABoLLValueShowableSliderTests/XCTestManifests.swift
+++ b/Tests/FABoLLValueShowableSliderTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(FABoLLValueShowableSliderTests.allTests),
-    ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import FABoLLValueShowableSliderTests
-
-var tests = [XCTestCaseEntry]()
-tests += FABoLLValueShowableSliderTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
## チケットへのリンク

なし

## やったこと

- Package を Swift 6 に変更
- FABoLLValueShowableSliderSettings を Sendable に変更してリファクタ
- View と Judging を FABoLLValueShowableSliderSettings の修正に合わせてリファクタ
- テストを Testing を利用するようにリファクタ
- README を更新

## やらないこと

上記以外

## 変わること

### できるようになること

なし

### できなくなること

なし

## 動作確認

- テストを修正してPassすることを確認
- demo プロジェクトで動作確認

## その他

なし